### PR TITLE
Fix invalid organisation config

### DIFF
--- a/respec/organisation-config.js
+++ b/respec/organisation-config.js
@@ -474,16 +474,16 @@ var organisationConfig = {
             publisher: "Geonovum",
             date: "November 2023"
         },
-        "JRC117836" { 
+        "JRC117836": {
             href: "https://op.europa.eu/en/publication-detail/-/publication/6521f427-01df-11ea-8c1f-01aa75ed71a1",
-            title: "The Relationship Between Open Source Software and Standard Setting",
+            title: "The Relationship Between Open Source Software and Standard Setting",
             authors: ["Knut Blind", "Mirko Böhm"],
             editors: ["Nikolaus Thumm"],
             publisher: "Joint Research Center",
             id: "JRC117836",
             date: "2019"
         },
-        "Krechmer2002" {
+        "Krechmer2002": {
             href: "https://www.isology.com/pdf/cathedrals.pdf",
             title: "Cathedrals, Libraries and Bazaars",
             authors: ["Ken Krechmer"],


### PR DESCRIPTION
Including removing an invisible character in the word `Software`.

Fixes issue #3