### PR TITLE
Mermaid zonder <pre>

### DIFF
--- a/respec/plugins/mermaid.mjs
+++ b/respec/plugins/mermaid.mjs
@@ -26,10 +26,10 @@ export async function generateMermaidFigures(config, document, utils) {
     if (figureName) {
       try {
         const fetchSource = await fetch(`./media/${figureName}`);
-        const preElement = document.createElement('pre');
-        preElement.prepend(document.createTextNode(await fetchSource.text()));
-        figure.replaceWith(preElement);
-        generatedFigures.push(preElement);
+        const divElement = document.createElement('div');
+        divElement.prepend(document.createTextNode(await fetchSource.text()));
+        figure.replaceWith(divElement);
+        generatedFigures.push(divElement);
       } catch (e) {
         utils.showError('Unable to generate Mermaid figure', {
           elements: [figure],

--- a/respec/plugins/mermaid.mjs
+++ b/respec/plugins/mermaid.mjs
@@ -47,8 +47,4 @@ export async function generateMermaidFigures(config, document, utils) {
   await mermaid.run({
     nodes: generatedFigures,
   });
-  // Remove code block background from generated images
-  for (const figure of generatedFigures) {
-    figure.classList.remove('hljs');
-  }
 }


### PR DESCRIPTION
Een Mermaidfiguur wordt smal in `<figure>`, zie [hier](https://logius-standaarden.github.io/Publicatie-Preview/Digikoppeling-Koppelvlakstandaard-REST-API/pr-timvdlippe-organisation-config/#fig-bescherming-voor-het-volledige-pad-client-naar-server). Het krijgt dan figure.pre styling:
https://github.com/Logius-standaarden/publicatie/blob/aeaadc62e640eef174953994fd89ea81848e7780/respec/style/base.css#L767-L770
Deze verandering zorgt dat het figuur zijn volle breedte krijgt:
```css
display: table;
```
Alhoewel did bij het testen niet meteen op het oog de opmaak van de daadwerkelijke codeblokken leek te wijzigen is het wellicht netter om simpelweg geen pre te gebruiken.