### PR TITLE
NCSC-richtlijnen

### DIFF
--- a/respec/organisation-config.mjs
+++ b/respec/organisation-config.mjs
@@ -397,12 +397,6 @@ const organisationConfig = {
       publisher: "IETF",
       title: "JSON Web Token (JWT)"
     },
-    "NCSC 2019": {
-      date: "April 2019",
-      href: "https://www.ncsc.nl/documenten/publicaties/2019/mei/01/ict-beveiligingsrichtlijnen-voor-transport-layer-security-tls",
-      publisher: "NCSC",
-      title: "ICT-beveiligingsrichtlijnen voor Transport Layer Security (TLS) v2.0"
-    },
     "NCSC 2021": {
       date: "Jan 2021",
       href: "https://www.ncsc.nl/documenten/publicaties/2021/januari/19/ict-beveiligingsrichtlijnen-voor-transport-layer-security-2.1",
@@ -413,7 +407,7 @@ const organisationConfig = {
       date: "June 2025",
       href: "https://www.ncsc.nl/wat-kun-je-zelf-doen/documenten/publicaties/2025/juni/01/ict-beveiligingsrichtlijnen-voor-transport-layer-security-2025-05",
       publisher: "NCSC",
-      title: "ICT-beveiligingsrichtlijnen voor Transport Layer Security (TLS) v2.1"
+      title: "Transport Layer Security (TLS) richtlijnen 2025-05"
     },
     "NEN3610": {
       authors: [""],


### PR DESCRIPTION
Versie uit 2019 (2.0) is verdwenen van de website van het NCSC; We refereerden er enkel nog informatief naar.
De titel van de versie van 2025 is daarnaast aangepast aan de daadwerkelijke titel van het document.