### PR TITLE
Update ADR link to version 2.1

### DIFF
--- a/respec/organisation-config.mjs
+++ b/respec/organisation-config.mjs
@@ -111,7 +111,7 @@ const organisationConfig = {
   localBiblio: {
     "ADR": {
       authors: ["Jasper Roes", "Joost Farla"],
-      href: "https://gitdocumentatie.logius.nl/publicatie/api/adr/2.0",
+      href: "https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1",
       publisher: "Logius",
       title: "API Design Rules"
     },


### PR DESCRIPTION
Bij de komende publicatie van Digikoppeling REST zal naar ADR 2.1 verwezen worden.