### PR TITLE
Update FSC-Core and FSC-Logging hrefs to new versions

### DIFF
--- a/respec/organisation-config.mjs
+++ b/respec/organisation-config.mjs
@@ -538,13 +538,13 @@ const organisationConfig = {
       date: "March 2002"
     },
     "FSC-Core": {
-      href: "https://gitdocumentatie.logius.nl/publicatie/fsc/core/1.0.0/",
+      href: "https://gitdocumentatie.logius.nl/publicatie/fsc/core/2.0.0/",
       title: "FSC - Core",
       authors: ["Eelco Hotting", "Ronald Koster", "Henk van Maanen", "Niels Dequeker", "Edward van Gelderen", "Pim Gaemers"],
       publisher: "Logius"
     },
     "FSC-Logging": {
-      href: "https://gitdocumentatie.logius.nl/publicatie/fsc/logging/1.0.0/",
+      href: "https://gitdocumentatie.logius.nl/publicatie/fsc/logging/1.1.0/",
       title: "FSC - Logging",
       authors: ["Eelco Hotting", "Ronald Koster", "Henk van Maanen", "Niels Dequeker", "Edward van Gelderen", "Pim Gaemers"],
       publisher: "Logius"


### PR DESCRIPTION
Om de referenties in de consultatieversies juist te hebben.