### PR TITLE
Fix links naar API strategie

### DIFF
--- a/api/adr/2.1.0/index.html
+++ b/api/adr/2.1.0/index.html
@@ -1008,7 +1008,7 @@ This document is part of the Nederlandse API Strategie, which consists of a set 
   </div>
   <section id="abstract" class="introductory"><h2>Abstract</h2><p>This document contains a normative standard for designing APIs in the Dutch Public Sector.
 The Governance of this standard is described by the <a href="https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/">API-Standaarden beheermodel</a> published by Logius.
-This document is part of the <em>Nederlandse API Strategie</em>, which consists of <a href="https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie">a set of documents</a>.</p>
+This document is part of the <em>Nederlandse API Strategie</em>, which consists of <a href="https://developer.overheid.nl/communities/kennisplatform-apis/#api-strategie">a set of documents</a>.</p>
 </section>
   <section class="notoc" id="conformance"><div class="header-wrapper"><h2 id="conformance-0">Conformance</h2><a class="self-link" href="#conformance" aria-label="Permalink for this Section"></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
         The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">NOT RECOMMENDED</em>, <em class="rfc2119">SHOULD</em>, and <em class="rfc2119">SHOULD NOT</em> in this document
@@ -1057,7 +1057,7 @@ This document is part of the <em>Nederlandse API Strategie</em>, which consists 
 <p>Despite the fact that two authors are mentioned in the list of authors, this document is the result of a collaborative effort by the members of the <em>API Design Rules Working Group</em>.</p>
 </section><section id="reading-guide"><div class="header-wrapper"><h3 id="x1-4-reading-guide"><bdi class="secno">1.4 </bdi>Reading Guide</h3><a class="self-link" href="#reading-guide" aria-label="Permalink for Section 1.4"></a></div>
 <p>This document is part of the <em>Nederlandse API Strategie</em>.</p>
-<p>The Nederlandse API Strategie consists of <a href="https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie">a set of distinct documents</a>.</p>
+<p>The Nederlandse API Strategie consists of <a href="https://developer.overheid.nl/communities/kennisplatform-apis/#api-strategie">a set of distinct documents</a>.</p>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
De links doen het niet meer, aangezien deze informatie nu op developer.overheid.nl staat.