### PR TITLE
Sta ook https://www.logius.nl toe

### DIFF
--- a/respec/organisation-config.mjs
+++ b/respec/organisation-config.mjs
@@ -681,7 +681,7 @@ export function loadRespecWithConfiguration(localConfig) {
         if (!('companyURL' in person)) {
           continue;
         }
-        if (person.companyURL.includes("logius.nl") && person.companyURL !== "https://logius.nl") {
+        if (person.companyURL.includes("logius.nl") && person.companyURL !== "https://logius.nl" && person.companyURL !== "https://www.logius.nl") {
           utils.showError(`companyURL of an editor/author of Logius must be "https://logius.nl", instead it was "${person.companyURL}"`);
         }
         if (person.companyURL.includes("github.com")) {


### PR DESCRIPTION
Dit is de uiteindelijke URL na redirecten, dus die moeten we overal gebruiken. Door beiden toe te staan breken we niet alle documenten, maar kunnen we ze wel gaan opschonen.

Part of #68