### PR TITLE
Sta ook `fundament/en` toe als shortName

### DIFF
--- a/respec/organisation-config.mjs
+++ b/respec/organisation-config.mjs
@@ -660,7 +660,8 @@ export function loadRespecWithConfiguration(localConfig) {
       if (!ACCEPTED_DOMAINS.includes(config.pubDomain)) {
         utils.showError(`Invalid pubDomain. Must be one of ${ACCEPTED_DOMAINS}, but was "${config.pubDomain}"`);
       }
-      if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(config.shortName)) {
+      // Alleen fundament heeft een Engelse versie die we toestaan als sub-shortname
+      if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(config.shortName) || config.shortName === "fundament/en") {
         utils.showError(`Invalid shortName. Must be in kebab-case (only lowercase letters and potentially separated by dashes), but was "${config.shortName}"`);
       }
       if (missingOrIsEmpty(config.github)) {


### PR DESCRIPTION
Anders kunnen we de Engelse versie van het BOMOS fundament niet meer bouwen.